### PR TITLE
E2357. Refactor sign_up_sheet_controller.rb

### DIFF
--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -154,7 +154,7 @@ class SignUpSheetController < ApplicationController
     # to treat all assignments as team assignments
     # Though called participants, @participants are actually records in signed_up_teams table, which
     # is a mapping table between teams and topics (waitlisted recorded are also counted)
-    #refactoring participants variable to team
+    #refactoring participants variable to team for readability
     @team = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
   end
 

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -241,24 +241,31 @@ class SignUpSheetController < ApplicationController
 
   def signup_as_instructor_action
     user = User.find_by(name: params[:username])
-    if user.nil? # validate invalid user
+  
+    if user.nil?
       flash[:error] = 'That student does not exist!'
     else
-      if AssignmentParticipant.exists? user_id: user.id, parent_id: params[:assignment_id]
-        if SignUpSheet.signup_team(params[:assignment_id], user.id, params[:topic_id])
+      #assign params[:assignment_id] and params[:topic_id] to variables and use these variables to avoid repetition 
+      assignment_id = params[:assignment_id]
+      topic_id = params[:topic_id]
+  
+      if AssignmentParticipant.exists?(user_id: user.id, parent_id: assignment_id)
+        if SignUpSheet.signup_team(assignment_id, user.id, topic_id)
           flash[:success] = 'You have successfully signed up the student for the topic!'
-          ExpertizaLogger.info LoggerMessage.new(controller_name, '', 'Instructor signed up student for topic: ' + params[:topic_id].to_s)
+          ExpertizaLogger.info LoggerMessage.new(controller_name, '', "Instructor signed up student for topic: #{topic_id}"))
         else
           flash[:error] = 'The student has already signed up for a topic!'
           ExpertizaLogger.info LoggerMessage.new(controller_name, '', 'Instructor is signing up a student who already has a topic')
         end
       else
         flash[:error] = 'The student is not registered for the assignment!'
-        ExpertizaLogger.info LoggerMessage.new(controller_name, '', 'The student is not registered for the assignment: ' << user.id)
+        ExpertizaLogger.info LoggerMessage.new(controller_name, '', "The student is not registered for the assignment: #{user.id}")
       end
     end
-    redirect_to controller: 'assignments', action: 'edit', id: params[:assignment_id]
+  
+    redirect_to(controller: 'assignments', action: 'edit', id: assignment_id)
   end
+  
 
   # this function is used to delete a previous signup
   def delete_signup

--- a/app/controllers/sign_up_sheet_controller.rb
+++ b/app/controllers/sign_up_sheet_controller.rb
@@ -154,7 +154,8 @@ class SignUpSheetController < ApplicationController
     # to treat all assignments as team assignments
     # Though called participants, @participants are actually records in signed_up_teams table, which
     # is a mapping table between teams and topics (waitlisted recorded are also counted)
-    @participants = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
+    #refactoring participants variable to team
+    @team = SignedUpTeam.find_team_participants(assignment_id, session[:ip])
   end
 
   def set_values_for_new_topic


### PR DESCRIPTION
* FIxed Signup_as_instructor_action has if-else ladder. It can be made more elegant.
* Refactor participants variable in  load_add_signup_topics
[In retrospect, the meaning of this is not clear.  The @participants variable is used in a way that is very obscure, with code spread across several views, and no comments saying what it is doing.  It used to be that participants (individual students) signed up for topics.  Now, only teams can sign up for topics.  So @participants does not make sense.
